### PR TITLE
logger: add escriba as default logger for doge

### DIFF
--- a/config/escriba-config.js
+++ b/config/escriba-config.js
@@ -1,0 +1,88 @@
+const log4js = require('log4js')
+const escriba = require('escriba')
+
+const log4jsConfig = {
+  appenders: [{
+    type: 'console',
+    layout: {
+      type: 'pattern',
+      pattern: '%[%m%]%n',
+    },
+  }],
+}
+
+log4js.configure(log4jsConfig)
+
+const escribaConfig = {
+  loggerEngine: log4js.getLogger(),
+  service: 'api-admin',
+  sensitive: {
+    api_admin: {
+      paths: [
+        'body.card_cvv',
+        'body.card_number',
+        'body.card_expiration_date',
+        'body.password',
+        'body.expiration_date',
+        'body.number',
+      ],
+      pattern: /\w.*/g,
+      replacer: '*',
+    },
+    keys: {
+      paths: [
+        'body.api_key',
+        'body.api_key.test',
+        'query',
+        'originalUrl',
+        'url',
+        'body.api_key.live',
+        'body.encryption_key.live',
+        'body.encryption_key.test',
+      ],
+      pattern: /"?session_id"?[=|:]"?(\w{60})"?|(ak_(live|test)_|ek_(live|test)_)(\w{30})/g,
+      replacer: '*',
+    },
+  },
+  httpConf: {
+    logIdPath: 'headers.x-request-id',
+    propsToLog: {
+      request: [
+        'id',
+        'method',
+        'url',
+        'body',
+        'headers.X-Request-ID',
+        'httpVersion',
+        'referrer',
+        'referer',
+        'user-agent',
+      ],
+      response: [
+        'id',
+        'method',
+        'url',
+        'company._id',
+        'company.name',
+        'status',
+        'body',
+        'httpVersion',
+        'referrer',
+        'referer',
+        'user-agent',
+        'latency',
+        'authenticationMethod',
+        'user._id',
+        'user.email',
+        'user.name',
+      ],
+    },
+    skipRules: {
+      bannedRoutes: [/\/status/],
+      bannedMethods: ['OPTIONS'],
+      bannedBodyRoutes: [/.*\.(csv|xlsx)$/, /\/search/],
+    },
+  },
+}
+
+module.exports = escriba(escribaConfig)

--- a/lib/doge/controller.js
+++ b/lib/doge/controller.js
@@ -47,6 +47,7 @@ module.exports = new Class('Controller', function() {
 		})
 		.then(function(response) {
 			if (response) {
+				this.response.user = Object.assign({}, this.user);
 				this.response.body = response;
 			}
 

--- a/lib/doge/middlewares/logger.js
+++ b/lib/doge/middlewares/logger.js
@@ -1,21 +1,59 @@
-var log4js = require('log4js');
-var Middleware = require('../middleware');
+const Middleware = require('../middleware')
+const { httpLogger } = require('../../../config/escriba-config')
 
-module.exports = new Class('Logger', Middleware, function() {
-	this.$.initialize = function(logger) {
-		if (!logger) {
-			logger = log4js.getLogger('HTTP');
-		}
+module.exports = new Class('Logger', Middleware, function Logger () {
+  this.$.initialize = function initialize (logger) {
+    if (!logger) {
+      logger = httpLogger
+    }
+    this.logger = logger
+  }
 
-		this.logger = logger;
-	};
-	
-	this.$.call = function(req, res, next) {
-		return next()
-		.bind(this)
-		.finally(function() {
-			this.logger.info('%s %s %s %s', req.remoteIp, req.method, req.url, res.status);
-		});
-	};
-});
+  this.$.call = function call (req, res, next) {
+    const preparePayload = () => {
+      let request = {}
+      let response = {}
+
+      try {
+        request = Object.assign(
+          {},
+          req,
+          {
+            body: JSON.parse(req.body.toString()),
+          }
+        )
+        response = Object.assign(
+          {},
+          res,
+          {
+            body: JSON.stringify(res.body),
+          }
+        )
+        response.end = () => {
+          /*
+            Escriba expected an express function called end that is
+            attached to the response object. This function is called
+            when the response process was finished, escriba get this
+            finished signal and create a log for response.
+            by @vitorabner
+           */
+        }
+      } catch (e) { }
+
+      return ({ request, response })
+    }
+
+    const logPayload = ({ request, response }) => {
+      this.logger(request, response, () => {})
+      if (response.body) {
+        response.end(response.body)
+      }
+    }
+
+    return next()
+      .bind(this)
+      .then(preparePayload)
+      .then(logPayload)
+  }
+})
 

--- a/lib/doge/middlewares/logger.js
+++ b/lib/doge/middlewares/logger.js
@@ -19,7 +19,7 @@ module.exports = new Class('Logger', Middleware, function Logger () {
           {},
           req,
           {
-            body: JSON.parse(req.body.toString()),
+            body: req.body.length > 0 ? JSON.parse(req.body.toString()) : {},
           }
         )
         response = Object.assign(

--- a/lib/doge/middlewares/logger.js
+++ b/lib/doge/middlewares/logger.js
@@ -38,7 +38,9 @@ module.exports = new Class('Logger', Middleware, function Logger () {
             by @vitorabner
            */
         }
-      } catch (e) { }
+      } catch (e) {
+        console.error(e)
+      }
 
       return ({ request, response })
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cuid": "^1.2.4",
     "dogeon": "^1.0.0",
     "dson-middleware": "0.0.5",
+    "escriba": "1.4.0",
     "express": "^4.12.3",
     "forwarded": "^0.1.0",
     "include-path": "^0.4.7",

--- a/test/middlewares/logger.js
+++ b/test/middlewares/logger.js
@@ -42,5 +42,5 @@ describe('Middlewares#Logger', function(){
 		});
 
 	});
-	
+
 });


### PR DESCRIPTION
Added escriba as the default logger for doge so we can know log the
body of both requests and responses. We also added important info
about which user made the request. This will allow us to better
debug on logentries